### PR TITLE
Update ServiceResolver.java

### DIFF
--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/protobuf/ServiceResolver.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/protobuf/ServiceResolver.java
@@ -155,8 +155,10 @@ public final class ServiceResolver {
 
         // Finally, construct the actual descriptor.
         Descriptors.FileDescriptor[] empty = new Descriptors.FileDescriptor[0];
-
-        return Descriptors.FileDescriptor.buildFrom(descriptorProto, dependencies.build().toArray(empty));
+        Descriptors.FileDescriptor descriptor = Descriptors.FileDescriptor.buildFrom(descriptorProto, dependencies.build().toArray(empty));
+        descriptorCache.put(descriptorName, descriptor);
+        
+        return descriptor;
     }
 
 }


### PR DESCRIPTION
The `descriptorCache` is never getting updated with the built descriptors. As a result, the nested descriptors are taking forever and running out of memory.