### PR TITLE
Could com.github.thinkerou:karate-grpc-core:1.0.3 drop off redundant dependencies?

### DIFF
--- a/karate-grpc-core/pom.xml
+++ b/karate-grpc-core/pom.xml
@@ -17,21 +17,65 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>${grpc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
             <version>${grpc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.android</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
             <version>${protobuf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>29.0-jre</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_com.github.thinkerou:karate-grpc-core:1.0.3_** introduced **_32_** dependencies. However, among them, **_6_** libraries (**_18%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.google.code.findbugs:jsr305:jar:3.0.2:compile
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
com.google.android:annotations:jar:4.1.1.4:compile
com.google.errorprone:error_prone_annotations:jar:2.3.2:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_com.google.code.findbugs:jsr305:jar:3.0.2:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_com.github.thinkerou:karate-grpc-core:1.0.3_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.github.thinkerou:karate-grpc-core:1.0.3_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/160546337-fe8bb166-2365-4dbf-9cac-502a241346d0.png)
