### PR TITLE
use consistent versioning to fix parent pom compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You need to add the following `<dependencies>`:
 Alternatively for Gradle you need to add the following entry:
 
 ```gradle
-testCompile 'com.github.thinkerou:karate-grpc-core:1.0.6'
+testImplementation 'com.github.thinkerou:karate-grpc-core:1.0.6'
 ```
 
 And simulates `karate-grpc-helper` and `karate-grpc-demo` build your redis helper project and test project.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You need to add the following `<dependencies>`:
 <dependency>
     <groupId>com.github.thinkerou</groupId>
     <artifactId>karate-grpc-core</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.6</version>
 </dependency>
 ```
 
@@ -67,7 +67,7 @@ You need to add the following `<dependencies>`:
 Alternatively for Gradle you need to add the following entry:
 
 ```gradle
-testCompile 'com.github.thinkerou:karate-grpc-core:1.0.3'
+testCompile 'com.github.thinkerou:karate-grpc-core:1.0.6'
 ```
 
 And simulates `karate-grpc-helper` and `karate-grpc-demo` build your redis helper project and test project.

--- a/karate-grpc-core/pom.xml
+++ b/karate-grpc-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>karate-grpc-parent</artifactId>
         <groupId>com.github.thinkerou</groupId>
-        <version>1.0.4</version>
+        <version>1.0.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/karate-grpc-demo/pom.xml
+++ b/karate-grpc-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>karate-grpc-parent</artifactId>
         <groupId>com.github.thinkerou</groupId>
-        <version>1.0.4</version>
+        <version>1.0.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.github.thinkerou</groupId>
             <artifactId>karate-grpc-proto</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.6</version>
         </dependency>
 
         <dependency>

--- a/karate-grpc-demo/src/test/java/demo/helloworld/record-route.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/record-route.feature
@@ -9,4 +9,5 @@ Feature: grpc helloworld example by grpc dynamic client
     * def payload = read('record-route.json')
     * def response = client.call('helloworld.Greeter/RecordRoute', payload)
     * def response = JSON.parse(response)
-    * match response[0] == { 'pointCount': 2, 'featureCount': 2, 'distance': 72948 }
+    * match response == '#[1]'
+    * match response[0] == { 'point_count': 2, 'feature_count': 2, 'distance': 72948, 'elapsed_time': 0 }

--- a/karate-grpc-helper/pom.xml
+++ b/karate-grpc-helper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>karate-grpc-parent</artifactId>
         <groupId>com.github.thinkerou</groupId>
-        <version>1.0.4</version>
+        <version>1.0.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/karate-grpc-proto/pom.xml
+++ b/karate-grpc-proto/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>karate-grpc-parent</artifactId>
+        <groupId>com.github.thinkerou</groupId>
+        <version>1.0.6</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>karate-grpc-proto</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.5.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/karate-grpc-proto/src/main/proto/demo/helloworld.proto
+++ b/karate-grpc-proto/src/main/proto/demo/helloworld.proto
@@ -1,0 +1,130 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.github.thinkerou.demo.helloworld";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+    rpc AgainSayHello (AgainHelloRequest) returns (AgainHelloReply) {}
+    // Streams a many greetings
+    rpc SayHelloBiStreaming (stream HelloRequest) returns (stream HelloReply) {}
+    rpc SayHelloClientStreaming (stream HelloRequest) returns (HelloReply) {}
+    rpc SayHelloServerStreaming (HelloRequest) returns (stream HelloReply) {}
+
+    // A simple RPC.
+    //
+    // Obtains the feature at a given position.
+    //
+    // A feature with an empty name is returned if there's no feature at the given
+    // position.
+    rpc GetFeature(Point) returns (Feature) {}
+
+    // A server-to-client streaming RPC.
+    //
+    // Obtains the Features available within the given Rectangle.  Results are
+    // streamed rather than returned at once (e.g. in a response message with a
+    // repeated field), as the rectangle may cover a large area and contain a
+    // huge number of features.
+    rpc ListFeatures(Rectangle) returns (stream Feature) {}
+
+    // A client-to-server streaming RPC.
+    //
+    // Accepts a stream of Points on a route being traversed, returning a
+    // RouteSummary when traversal is completed.
+    rpc RecordRoute(stream Point) returns (RouteSummary) {}
+
+    // A Bidirectional streaming RPC.
+    //
+    // Accepts a stream of RouteNotes sent while a route is being traversed,
+    // while receiving other RouteNotes (e.g. from other users).
+    rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}
+
+message AgainHelloRequest {
+    string message = 1;
+    string address = 2;
+}
+
+message AgainHelloReply {
+    string details = 1;
+}
+
+// Complex message
+
+// Points are represented as latitude-longitude pairs in the E7 representation
+// (degrees multiplied by 10**7 and rounded to the nearest integer).
+// Latitudes should be in the range +/- 90 degrees and longitude should be in
+// the range +/- 180 degrees (inclusive).
+message Point {
+    int32 latitude = 1;
+    int32 longitude = 2;
+}
+
+// A latitude-longitude rectangle, represented as two diagonally opposite
+// points "lo" and "hi".
+message Rectangle {
+    // One corner of the rectangle.
+    Point lo = 1;
+
+    // The other corner of the rectangle.
+    Point hi = 2;
+}
+
+// A feature names something at a given point.
+//
+// If a feature could not be named, the name is empty.
+message Feature {
+    // The name of the feature.
+    string name = 1;
+
+    // The point where the feature is detected.
+    Point location = 2;
+}
+
+// Not used in the RPC.  Instead, this is here for the form serialized to disk.
+message FeatureDatabase {
+    repeated Feature feature = 1;
+}
+
+// A RouteNote is a message sent while at a given point.
+message RouteNote {
+    // The location from which the message is sent.
+    Point location = 1;
+
+    // The message to be sent.
+    string message = 2;
+}
+
+// A RouteSummary is received in response to a RecordRoute rpc.
+//
+// It contains the number of individual points received, the number of
+// detected features, and the total distance covered as the cumulative sum of
+// the distance between each point.
+message RouteSummary {
+    // The number of points received.
+    int32 point_count = 1;
+
+    // The number of known features passed while traversing the route.
+    int32 feature_count = 2;
+
+    // The distance covered in metres.
+    int32 distance = 3;
+
+    // The duration of the traversal in seconds.
+    int32 elapsed_time = 4;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>com.thinkerou</groupId>
                 <artifactId>karate-grpc-proto</artifactId>
-                <version>1.0.6</version>
+                <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.thinkerou</groupId>
     <artifactId>karate-grpc-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.4</version>
+    <version>1.0.6</version>
 
     <name>${project.artifactId}</name>
     <description>gRPC Testing Made Simple by Karate.</description>
@@ -50,6 +50,7 @@
     </properties>
 
     <modules>
+        <module>karate-grpc-proto</module>
         <module>karate-grpc-core</module>
         <module>karate-grpc-demo</module>
         <module>karate-grpc-helper</module>
@@ -70,7 +71,7 @@
             <dependency>
                 <groupId>com.thinkerou</groupId>
                 <artifactId>karate-grpc-proto</artifactId>
-                <version>1.0.3</version>
+                <version>1.0.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
use consistent version for all modules

restore proto since it's still referenced in the demo (required for consistent versioning)
bump version to 1.0.6

Addresses https://github.com/pecker-io/karate-grpc/issues/26 https://github.com/pecker-io/karate-grpc/issues/22