### PR TITLE
update karate version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,14 +202,14 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = Client.create('localhost', 50051)
 
   Scenario: do it
-    * def payload = read('helloworld.json')
+    * string payload = read('helloworld.json')
     * def response = client.call('helloworld.Greeter/SayHello', payload)
     * def response = JSON.parse(response)
     * print response
     * match response[0].message == 'Hello thinkerou'
     * def message = response[0].message
 
-    * def payload = read('again-helloworld.json')
+    * string payload = read('again-helloworld.json')
     * def response = client.call('helloworld.Greeter/AgainSayHello', payload)
     * def response = JSON.parse(response)
     * match response[0].details == 'Details Hello thinkerou in BeiJing'
@@ -264,14 +264,14 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('helloworld.json')
+    * string payload = read('helloworld.json')
     * def response = client.call('helloworld.Greeter/SayHello', payload)
     * def response = JSON.parse(response)
     * print response
     * match response[0].message == 'Hello thinkerou'
     * def message = response[0].message
 
-    * def payload = read('again-helloworld.json')
+    * string payload = read('again-helloworld.json')
     * def response = client.call('helloworld.Greeter/AgainSayHello', payload)
     * def response = JSON.parse(response)
     * match response[0].details == 'Details Hello thinkerou in BeiJing'

--- a/karate-grpc-demo/pom.xml
+++ b/karate-grpc-demo/pom.xml
@@ -23,13 +23,6 @@
             <artifactId>karate-grpc-proto</artifactId>
             <version>1.0.6</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.intuit.karate</groupId>
-            <artifactId>karate-apache</artifactId>
-            <version>${karate.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-junit4</artifactId>

--- a/karate-grpc-demo/src/test/java/demo/DemoTest.java
+++ b/karate-grpc-demo/src/test/java/demo/DemoTest.java
@@ -1,14 +1,15 @@
 package demo;
 
-import cucumber.api.CucumberOptions;
-
 /**
  * DemoTest
  *
  * @author thinkerou
  */
-@CucumberOptions(tags = {"~@ignore"})
 public class DemoTest extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:";
+    }
 
     /**
      * This class will automatically pick up all *.feature files in src/test/java/demo

--- a/karate-grpc-demo/src/test/java/demo/DemoTestParallel.java
+++ b/karate-grpc-demo/src/test/java/demo/DemoTestParallel.java
@@ -1,62 +1,9 @@
 package demo;
 
-import static org.junit.Assert.assertTrue;
+public class DemoTestParallel extends TestBase {
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.intuit.karate.cucumber.CucumberRunner;
-import com.intuit.karate.cucumber.KarateStats;
-
-import cucumber.api.CucumberOptions;
-import net.masterthought.cucumber.Configuration;
-import net.masterthought.cucumber.ReportBuilder;
-
-/**
- * DemoTestParallel
- *
- * @author thinkerou
- */
-@CucumberOptions(tags = {"~@ignore"}) // IMPORTANT: don't use @RunWith(Karate.class)
-public class DemoTestParallel {
-
-    private static final int THREAD_COUNT = 1;
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        TestBase.beforeClass();
+    @Override
+    protected String getFeatures() {
+        return "classpath:";
     }
-
-    @AfterClass
-    public static void afterClass() {
-        TestBase.afterClass();
-    }
-
-    @Test
-    public void testParallel() {
-        String outputPath = "target/surefire-reports";
-        KarateStats stats = CucumberRunner.parallel(getClass(), THREAD_COUNT, outputPath);
-        generateReport(outputPath);
-        assertTrue("There are scenario failure", stats.getFailCount() == 0);
-    }
-
-    private static void generateReport(String outputPath) {
-        Collection<File> jsonFiles = FileUtils.listFiles(new File(outputPath), new String[] {"json"}, true);
-
-        List<String> jsonPaths = new ArrayList<>(jsonFiles.size());
-        jsonFiles.forEach(file -> jsonPaths.add(file.getAbsolutePath()));
-
-        Configuration config = new Configuration(new File("target"), "gRPC Test by Karate");
-
-        ReportBuilder reportBuilder = new ReportBuilder(jsonPaths, config);
-        reportBuilder.generateReports();
-    }
-
 }

--- a/karate-grpc-demo/src/test/java/demo/TestBase.java
+++ b/karate-grpc-demo/src/test/java/demo/TestBase.java
@@ -1,21 +1,30 @@
 package demo;
 
-import org.junit.AfterClass;
+import com.intuit.karate.Results;
+import com.intuit.karate.Runner;
+import net.masterthought.cucumber.Configuration;
+import net.masterthought.cucumber.ReportBuilder;
+import org.apache.commons.io.FileUtils;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-
-import com.intuit.karate.junit4.Karate;
-
+import org.junit.Test;
 import testing.ServerStart;
 
-/**
- * TestBase
- *
- * @author thinkerou
- */
-@RunWith(Karate.class)
-public class TestBase {
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author ericdriggs
+ */
+// important: do not use @RunWith(Karate.class) !
+public abstract class TestBase {
+
+    protected static final int THREAD_COUNT = 1;
+    protected abstract String getFeatures();
     private static ServerStart server;
 
     @BeforeClass
@@ -26,9 +35,24 @@ public class TestBase {
         server.startServer();
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @Test
+    public void testParallel() {
+        Results results = Runner.path(getFeatures())
+                .outputCucumberJson(true)
+                .outputHtmlReport(true)
+                .outputJunitXml(true)
+                .parallel(THREAD_COUNT);
+        generateReport(results.getReportDir());
+        assertTrue(results.getErrorMessages(), results.getFailCount() == 0);
+    }
 
+    public void generateReport(String karateOutputPath) {
+        Collection<File> jsonFiles = FileUtils.listFiles(new File(karateOutputPath), new String[] {"json"}, true);
+        List<String> jsonPaths = new ArrayList<>(jsonFiles.size());
+        jsonFiles.forEach(file -> jsonPaths.add(file.getAbsolutePath()));
+        Configuration config = new Configuration(new File("target"), getFeatures());
+        ReportBuilder reportBuilder = new ReportBuilder(jsonPaths, config);
+        reportBuilder.generateReports();
     }
 
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/GetFeatureRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/GetFeatureRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/get-feature.feature")
 public class GetFeatureRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/get-feature.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/HelloWorldListRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/HelloWorldListRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/helloworld-list.feature")
 public class HelloWorldListRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/helloworld-list.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/HelloWorldNewRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/HelloWorldNewRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/helloworld-new.feature")
 public class HelloWorldNewRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/helloworld-new.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/HelloWorldRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/HelloWorldRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/helloworld.feature")
 public class HelloWorldRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/helloworld.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/HelloworldBiStreamRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/HelloworldBiStreamRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/bi-stream.feature")
 public class HelloworldBiStreamRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/bi-stream.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/HelloworldClientStreamRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/HelloworldClientStreamRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/client-stream.feature")
 public class HelloworldClientStreamRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/client-stream.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/HelloworldServerStreamRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/HelloworldServerStreamRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/server-stream.feature")
 public class HelloworldServerStreamRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+         return "classpath:demo/helloworld/server-stream.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/ListFeaturesRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/ListFeaturesRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/list-features.feature")
 public class ListFeaturesRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/list-features.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/RecordRouteRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/RecordRouteRunner.java
@@ -1,6 +1,5 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
 /**
@@ -8,6 +7,9 @@ import demo.TestBase;
  *
  * @author thinkerou
  */
-@CucumberOptions(features = "classpath:demo/helloworld/record-route.feature")
 public class RecordRouteRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/record-route.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/RouteChatListRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/RouteChatListRunner.java
@@ -1,13 +1,10 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
-/**
- * RouteChatListRunner
- *
- * @author thinkerou
- */
-@CucumberOptions(features = "classpath:demo/helloworld/route-chat-list.feature")
 public class RouteChatListRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/route-chat-list.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/RouteChatRunner.java
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/RouteChatRunner.java
@@ -1,13 +1,10 @@
 package demo.helloworld;
 
-import cucumber.api.CucumberOptions;
 import demo.TestBase;
 
-/**
- * RouteChatRunner
- *
- * @author thinkerou
- */
-@CucumberOptions(features = "classpath:demo/helloworld/route-chat.feature")
 public class RouteChatRunner extends TestBase {
+    @Override
+    protected String getFeatures() {
+        return "classpath:demo/helloworld/route-chat.feature";
+    }
 }

--- a/karate-grpc-demo/src/test/java/demo/helloworld/bi-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/bi-stream.feature
@@ -6,7 +6,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('bistream.json')
+    * string payload = read('bistream.json')
     * def response = client.call('helloworld.Greeter/SayHelloBiStreaming', payload)
     * def response = JSON.parse(response)
     * match response[*].message == ['Hello thinkerou', 'Hello thinkerou2', 'Hello thinkerou3']

--- a/karate-grpc-demo/src/test/java/demo/helloworld/client-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/client-stream.feature
@@ -6,7 +6,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('clientstream.json')
+    * string payload = read('clientstream.json')
     * def response = client.call('helloworld.Greeter/SayHelloClientStreaming', payload)
     * def response = JSON.parse(response)
     * match response[0].message == 'Hello thinkerou and thinkerou2 and thinkerou3'

--- a/karate-grpc-demo/src/test/java/demo/helloworld/get-feature.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/get-feature.feature
@@ -6,7 +6,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('get-feature.json')
+    * string payload = read('get-feature.json')
     * def response = client.call('helloworld.Greeter/GetFeature', payload)
     * def response = JSON.parse(response)
     * match response[0].name == '352 South Mountain Road, Wallkill, NY 12589, USA'

--- a/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature
@@ -6,13 +6,13 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('helloworld.json')
+    * string payload = read('helloworld.json')
     * def response = client.call('helloworld.Greeter/SayHello', payload)
     * def response = JSON.parse(response)
     * match response[0].message == 'Hello thinkerou'
     * def message = response[0].message
 
-    * def payload = read('again-helloworld.json')
+    * string payload = read('again-helloworld.json')
     * def response = client.call('helloworld.Greeter/AgainSayHello', payload)
     * def response = JSON.parse(response)
     * match response[0].details == 'Details Hello thinkerou in BeiJing'

--- a/karate-grpc-demo/src/test/java/demo/helloworld/helloworld.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/helloworld.feature
@@ -5,13 +5,13 @@ Feature: grpc helloworld example
     * def client = new Client('localhost', 50051)
 
   Scenario: do it
-    * def payload = read('helloworld.json')
+    * string payload = read('helloworld.json')
     * def response = client.greet(payload)
     * def response = JSON.parse(response)
     * match response.message == 'Hello thinkerou'
     * def message = response.message
 
-    * def payload = read('again-helloworld.json')
+    * string payload = read('again-helloworld.json')
     * def response = client.againGreet(payload)
     * eval client.shutdown()
     * def response = JSON.parse(response)

--- a/karate-grpc-demo/src/test/java/demo/helloworld/list-features.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/list-features.feature
@@ -6,7 +6,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('list-features.json')
+    * string payload = read('list-features.json')
     * def response = client.call('helloworld.Greeter/ListFeatures', payload)
     * def response = JSON.parse(response)
     * match response[0].name == 'Patriots Path, Mendham, NJ 07945, USA'

--- a/karate-grpc-demo/src/test/java/demo/helloworld/record-route.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/record-route.feature
@@ -6,7 +6,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('record-route.json')
+    * string payload = read('record-route.json')
     * def response = client.call('helloworld.Greeter/RecordRoute', payload)
     * def response = JSON.parse(response)
     * match response == '#[1]'

--- a/karate-grpc-demo/src/test/java/demo/helloworld/route-chat.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/route-chat.feature
@@ -6,7 +6,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('route-chat.json')
+    * string payload = read('route-chat.json')
     * def response = client.call('helloworld.Greeter/RouteChat', payload)
     * def response = JSON.parse(response)
     * print response

--- a/karate-grpc-demo/src/test/java/demo/helloworld/server-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/server-stream.feature
@@ -6,7 +6,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * def client = client.redis('localhost', 6379)
 
   Scenario: do it
-    * def payload = read('serverstream.json')
+    * string payload = read('serverstream.json')
     * def response = client.call('helloworld.Greeter/SayHelloServerStreaming', payload)
     * def response = JSON.parse(response)
     * match response[*].message == ['Hello thinkerou part 0', 'Hello thinkerou part 1', 'Hello thinkerou part 2']

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.surefire.version>2.10</maven.surefire.version>
-        <karate.version>0.9.3</karate.version>
+        <karate.version>1.2.0</karate.version>
         <cucumber.reporting.version>3.20.0</cucumber.reporting.version>
         <grpc.version>1.21.0</grpc.version>
         <protobuf.version>3.7.1</protobuf.version>


### PR DESCRIPTION
refactor tests to use runner since CucumberOptions / KarateOptions are deprecated/removed
refactor payloads to type string since graal no longer handles implicit string conversions from js lists
remove deprecated/removed library karate-apache

note: "~@ignore" no longer required since Runner automatically excludes this keyword