### PR TITLE
Support mock jedis. Make thread safe. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ So, use `karate-grpc` need the following steps:
 1. Calls into karate-grpc GrpcClient via Java Interop.
 
 ```
-* def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
+* def GrpcClient = Java.type('com.github.thinkerou.karate.GrpcClient')
 ```
 
 2. Builds one public Grpc client using your grpc ip and port.
 
 ```
-* def client = Client.create('localhost', 50051)
+* def client = new GrpcClient('localhost', 50051)
 ```
 
 If you want to list protobuf by service name or/and message name, you should use:
 
 ```
-* def client = Client.create()
+* def client = new GrpcClient()
 ```
 
 Because not need grpc server ip/port when listing protobuf.
@@ -192,14 +192,12 @@ One whole example likes [this](karate-grpc-demo/src/test/java/demo/helloworld/he
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('helloworld.json')
     * def response = client.call('helloworld.Greeter/SayHello', payload)
     * def response = JSON.parse(response)
-    * print response
     * match response[0].message == 'Hello thinkerou'
     * def message = response[0].message
 
@@ -252,28 +250,22 @@ Uses jedis-mock so you don't even need to install Redis.
  [example](karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature):
 
 ```
-Feature: grpc helloworld example by grpc dynamic client
+public enum DemoGrpcClientSingleton {
+    INSTANCE;
 
-  Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    RedisGrpcClient redisGrpcClient;
 
-  Scenario: do it
-    * string payload = read('helloworld.json')
-    * def response = client.call('helloworld.Greeter/SayHello', payload)
-    * def response = JSON.parse(response)
-    * print response
-    * match response[0].message == 'Hello thinkerou'
-    * def message = response[0].message
+    public GrpcClient getGrpcClient() {
+        return redisGrpcClient;
+    }
 
-    * string payload = read('again-helloworld.json')
-    * def response = client.call('helloworld.Greeter/AgainSayHello', payload)
-    * def response = JSON.parse(response)
-    * match response[0].details == 'Details Hello thinkerou in BeiJing'
+    DemoGrpcClientSingleton() {
+        redisGrpcClient = new RedisGrpcClient("localhost", 50051, MockRedisSingleton.INSTANCE.getRedisHelper());
+    }
+}
 ```
 
-Only use the line `* def client = client.redis()` it's OK!
+To use redis, use class `com.github.thinkerou.karate.RedisGrpcClient` instead of `com.github.thinkerou.karate.GrpClient`
 
 **TODO:**
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you want to list protobuf by service name or/and message name, you should use
 * def client = new GrpcClient()
 ```
 
-Because not need grpc server ip/port when listing protobuf.
+Because you don't need grpc server ip/port when listing protobuf.
 
 3. Reads JSON data corresponding your protobuf definition.
 
@@ -240,15 +240,22 @@ Output JSON string also like:
 
 **That's all!!!**
 
-## Why use Redis?
+## Redis
+
+### Why use Redis?
 
 Using redis is optional, but caching descriptor sets may save compile time, especially when your project has many protobuf jar package dependencies.
 
-Uses jedis-mock so you don't even need to install Redis.
+### Mock Redis
+You can even use jedis-mock so you don't even need to install Redis.
+see [MockRedisSingleton.java](karate-grpc-core/com/github/thinkerou/karate/utils/MockRedisSingleton.java): 
 
+### Redis performance
 <i>Note: while the redis test implementation is thread-safe, Redis uses single-threaded execution so test performance may be degraded for high concurrency.</i>  
 
- [example](karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature):
+To use redis, use class `com.github.thinkerou.karate.RedisGrpcClient` instead of `com.github.thinkerou.karate.GrpClient`
+
+[example](karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature):
 
 ```
 public enum DemoGrpcClientSingleton {
@@ -265,9 +272,6 @@ public enum DemoGrpcClientSingleton {
     }
 }
 ```
-
-To use redis, use class `com.github.thinkerou.karate.RedisGrpcClient` instead of `com.github.thinkerou.karate.GrpClient`
-
 **TODO:**
 
 - Save `ProtoFullName|InputType|InputMessage|OutputType|OutputMessage|ProtoFileName|RPCAddress` not file content.

--- a/README.md
+++ b/README.md
@@ -238,11 +238,13 @@ Output JSON string also like:
 
 **That's all!!!**
 
-## Why need Redis?
+## Why use Redis?
 
 Using redis is optional, but caching descriptor sets may save compile time, especially when your project has many protobuf jar package dependencies.
 
 Uses jedis-mock so you don't even need to install Redis.
+
+<i>Note: while the redis test implementation is thread-safe, it uses single-threaded execution so test performance may be degraded for high concurrency.</i>  
 
  [example](karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature):
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Using redis is optional, but caching descriptor sets may save compile time, espe
 
 Uses jedis-mock so you don't even need to install Redis.
 
-<i>Note: while the redis test implementation is thread-safe, it uses single-threaded execution so test performance may be degraded for high concurrency.</i>  
+<i>Note: while the redis test implementation is thread-safe, Redis uses single-threaded execution so test performance may be degraded for high concurrency.</i>  
 
  [example](karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature):
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * string payload = read('helloworld.json')
     * def response = client.call('helloworld.Greeter/SayHello', payload)
     * def response = JSON.parse(response)
+    * print response
     * match response[0].message == 'Hello thinkerou'
     * def message = response[0].message
 

--- a/README.md
+++ b/README.md
@@ -12,27 +12,21 @@ karate-grpc can get all the benefits of [karate](https://github.com/intuit/karat
 
 ## Testing hello world
 
-Prefer to use Maven:
-
 ```
 $ # compile the whole project
-$ mvn clean compile package -Dmaven.test.skip=true
-$
-$ # start redis-server, first need to install it
-$ redis-server
-$
-$ # generate protobuf descriptor sets and put to redis
-$ cd karate-grpc-helper && mvn exec:java -Dexec.mainClass=com.github.thinkerou.karate.helper.Main
-$
-$ # test it
+$ mvn clean install
+
+$ # test the whole project
+$ mvn test
+
+$ # test demo
 $ cd karate-grpc-demo
-$ # run all tests
 $ mvn test
 $ # or run single test
 $ mvn test -Dtest=HelloWorldNewRunner
 ```
 
-Because have started hello world server on `AbstractTestBase.java`, we not need to start it alone.
+Because have started hello world server on `TestBase.java`, we not need to start it alone.
 
 Base on karate generates beautiful test report:
 
@@ -253,7 +247,9 @@ Output JSON string also like:
 
 So, use Redis to save descriptor sets which every generate.
 
-Indicates redis address and ask `karate-karate-core` to use redis, for [example](karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature):
+Uses jedis-mock so you don't even need to install Redis.
+
+ [example](karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature):
 
 ```
 Feature: grpc helloworld example by grpc dynamic client
@@ -261,7 +257,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('helloworld.json')
@@ -277,7 +273,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * match response[0].details == 'Details Hello thinkerou in BeiJing'
 ```
 
-Only use the line `* def client = client.redis('localhost', 6379)` it's OK!
+Only use the line `* def client = client.redis()` it's OK!
 
 **TODO:**
 

--- a/README.md
+++ b/README.md
@@ -240,9 +240,7 @@ Output JSON string also like:
 
 ## Why need Redis?
 
-> When your project have many protobuf jar package dependency, every compile will spend more time.
-
-So, use Redis to save descriptor sets which every generate.
+Using redis is optional, but caching descriptor sets may save compile time, especially when your project has many protobuf jar package dependencies.
 
 Uses jedis-mock so you don't even need to install Redis.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ # or run single test
 $ mvn test -Dtest=HelloWorldNewRunner
 ```
 
-Because have started hello world server on `TestBase.java`, we not need to start it alone.
+Because have started hello world server on `AbstractTestBase.java`, we not need to start it alone.
 
 Base on karate generates beautiful test report:
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Using redis is optional, but caching descriptor sets may save compile time, espe
 
 ### Mock Redis
 You can even use jedis-mock so you don't even need to install Redis.
-see [MockRedisSingleton.java](karate-grpc-core/com/github/thinkerou/karate/utils/MockRedisSingleton.java): 
+see [MockRedisHelperSingleton.java](karate-grpc-core/com/github/thinkerou/karate/utils/MockRedisHelperSingleton.java): 
 
 ### Redis performance
 <i>Note: while the redis test implementation is thread-safe, Redis uses single-threaded execution so test performance may be degraded for high concurrency.</i>  
@@ -268,7 +268,7 @@ public enum DemoGrpcClientSingleton {
     }
 
     DemoGrpcClientSingleton() {
-        redisGrpcClient = new RedisGrpcClient("localhost", 50051, MockRedisSingleton.INSTANCE.getRedisHelper());
+        redisGrpcClient = new RedisGrpcClient("localhost", 50051, MockRedisHelperSingleton.INSTANCE.getRedisHelper());
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,11 +13,8 @@ karate-grpc can get all the benefits of [karate](https://github.com/intuit/karat
 ## Testing hello world
 
 ```
-$ # compile the whole project
+$ # compile and test the whole project
 $ mvn clean install
-
-$ # test the whole project
-$ mvn test
 
 $ # test demo
 $ cd karate-grpc-demo

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ karate-grpc makes it easy to:
 [![karate-grpc-hello-world](assets/karate-grpc-hello-world.png)](assets/karate-grpc-hello-world.png)
 
 ## Testing hello world
-
+Requires maven to be installed
 ```
 $ # compile and test the whole project
 $ mvn clean install

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 [![Build Status](https://api.travis-ci.org/thinkerou/karate-grpc.svg)](https://travis-ci.org/thinkerou/karate-grpc)
 
-karate-grpc made gRPC testing simple by [karate](https://github.com/intuit/karate), and its dynamic client built based on [polyglot](https://github.com/grpc-ecosystem/polyglot).
+simple gRPC testing with [karate](https://github.com/intuit/karate) and a dynamic client using [polyglot](https://github.com/grpc-ecosystem/polyglot).
 
-karate-grpc can get all the benefits of [karate](https://github.com/intuit/karate#features), it makes it really easy to build protobuf complex request payloads via json, traverse data within the responses and chain data from responses into the next request.
+karate-grpc makes it easy to:
+* build complex protobuf request payloads via json
+* traverse data within the responses 
+* chain data from responses into the next request.
 
 ## Hello World
 
@@ -23,9 +26,9 @@ $ # or run single test
 $ mvn test -Dtest=HelloWorldNewRunner
 ```
 
-Because have started hello world server on `AbstractTestBase.java`, we not need to start it alone.
+When running tests, the hello world grpc server is started/stopped automatically in `AbstractTestBase.java`.
 
-Base on karate generates beautiful test report:
+Karate also generates beautiful test reports:
 
 [![karate-grpc-hello-world-report](assets/karate-grpc-hello-world-report.png)](assets/karate-grpc-hello-world-report.png)
 

--- a/karate-grpc-core/pom.xml
+++ b/karate-grpc-core/pom.xml
@@ -80,9 +80,14 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.9.0</version>
+            <version>4.2.3</version>
             <type>jar</type>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.fppt</groupId>
+            <artifactId>jedis-mock</artifactId>
+            <version>1.0.3</version>
         </dependency>
     </dependencies>
 

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/GrpcClient.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/GrpcClient.java
@@ -31,9 +31,9 @@ public final class GrpcClient {
         this.listIns = GrpcList.create();
     }
 
-    public GrpcClient redis(String host, int port) {
+    public GrpcClient redis() {
         if (redisHelper == null) {
-            redisHelper = RedisHelper.create(host, port);
+            redisHelper = new RedisHelper();
         }
         return this;
     }

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/GrpcClient.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/GrpcClient.java
@@ -10,8 +10,8 @@ import com.github.thinkerou.karate.service.GrpcList;
  */
 public class GrpcClient {
 
-    private GrpcCall callIns;
-    private GrpcList listIns;
+    protected GrpcCall callIns;
+    protected GrpcList listIns;
 
     public GrpcClient(String host, int port) {
         this.callIns = GrpcCall.create(host, port);

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
@@ -2,35 +2,43 @@ package com.github.thinkerou.karate;
 
 import com.github.thinkerou.karate.service.GrpcCall;
 import com.github.thinkerou.karate.service.GrpcList;
+import com.github.thinkerou.karate.utils.RedisHelper;
 
 /**
  * GrpcClient
  *
  * @author thinkerou
  */
-public class GrpcClient {
+public class RedisGrpcClient extends GrpcClient {
 
     private GrpcCall callIns;
     private GrpcList listIns;
+    private RedisHelper redisHelper;
 
-    public GrpcClient(String host, int port) {
+
+    public RedisGrpcClient(String host, int port, RedisHelper redisHelper) {
         this.callIns = GrpcCall.create(host, port);
+        this.redisHelper = redisHelper;
     }
 
-    public GrpcClient() {
+    public RedisGrpcClient(RedisHelper redisHelper) {
         this.listIns = GrpcList.create();
+        this.redisHelper = redisHelper;
     }
 
     public String call(String name, String payload) {
-        return callIns.invoke(name, payload);
+        return callIns.invokeByRedis(name, payload, redisHelper);
+
     }
 
     public String list(String serviceFilter, String methodFilter, Boolean withMessage) {
-        return listIns.invoke(serviceFilter, methodFilter, withMessage);
+
+        return listIns.invokeByRedis(serviceFilter, methodFilter, withMessage, redisHelper);
+
     }
 
     public String list(String name, Boolean withMessage) {
-        return listIns.invoke(name, withMessage);
+        return listIns.invokeByRedis(name, withMessage, redisHelper);
     }
 
 }

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
@@ -3,9 +3,10 @@ package com.github.thinkerou.karate;
 import com.github.thinkerou.karate.utils.RedisHelper;
 
 /**
- * GrpcClient
+ * RedisGrpcClient
+ * A GrpcClient which uses redis to cache protobuf descriptor sets
  *
- * @author thinkerou
+ * @author ericdriggs
  */
 public class RedisGrpcClient extends GrpcClient {
 
@@ -23,7 +24,6 @@ public class RedisGrpcClient extends GrpcClient {
 
     public String call(String name, String payload) {
         return callIns.invokeByRedis(name, payload, redisHelper);
-
     }
 
     public String list(String serviceFilter, String methodFilter, Boolean withMessage) {

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
@@ -1,7 +1,5 @@
 package com.github.thinkerou.karate;
 
-import com.github.thinkerou.karate.service.GrpcCall;
-import com.github.thinkerou.karate.service.GrpcList;
 import com.github.thinkerou.karate.utils.RedisHelper;
 
 /**
@@ -11,18 +9,15 @@ import com.github.thinkerou.karate.utils.RedisHelper;
  */
 public class RedisGrpcClient extends GrpcClient {
 
-    private GrpcCall callIns;
-    private GrpcList listIns;
     private RedisHelper redisHelper;
 
-
     public RedisGrpcClient(String host, int port, RedisHelper redisHelper) {
-        this.callIns = GrpcCall.create(host, port);
+        super(host, port);
         this.redisHelper = redisHelper;
     }
 
     public RedisGrpcClient(RedisHelper redisHelper) {
-        this.listIns = GrpcList.create();
+        super();
         this.redisHelper = redisHelper;
     }
 
@@ -32,9 +27,7 @@ public class RedisGrpcClient extends GrpcClient {
     }
 
     public String list(String serviceFilter, String methodFilter, Boolean withMessage) {
-
         return listIns.invokeByRedis(serviceFilter, methodFilter, withMessage, redisHelper);
-
     }
 
     public String list(String name, Boolean withMessage) {

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/RedisGrpcClient.java
@@ -22,14 +22,17 @@ public class RedisGrpcClient extends GrpcClient {
         this.redisHelper = redisHelper;
     }
 
+    @Override
     public String call(String name, String payload) {
         return callIns.invokeByRedis(name, payload, redisHelper);
     }
 
+    @Override
     public String list(String serviceFilter, String methodFilter, Boolean withMessage) {
         return listIns.invokeByRedis(serviceFilter, methodFilter, withMessage, redisHelper);
     }
 
+    @Override
     public String list(String name, Boolean withMessage) {
         return listIns.invokeByRedis(name, withMessage, redisHelper);
     }

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/JedisMock.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/JedisMock.java
@@ -1,0 +1,34 @@
+package com.github.thinkerou.karate.utils;
+
+import com.github.fppt.jedismock.RedisServer;
+
+import java.io.IOException;
+
+public class JedisMock {
+
+    private volatile static RedisServer redisServer;
+
+    public static RedisServer getRedisServer() {
+        init();
+        return redisServer;
+    }
+
+    public static void init() {
+        if (redisServer != null) {
+            return;
+        }
+        synchronized (JedisMock.class) {
+            if (redisServer != null) {
+                return;
+            }
+            try {
+                redisServer = RedisServer
+                        .newRedisServer()
+                        .start();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/JedisMock.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/JedisMock.java
@@ -4,6 +4,9 @@ import com.github.fppt.jedismock.RedisServer;
 
 import java.io.IOException;
 
+/**
+ * A singleton redis mock using jedis mock
+ */
 public class JedisMock {
 
     private volatile static RedisServer redisServer;

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/MockRedisHelperSingleton.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/MockRedisHelperSingleton.java
@@ -5,11 +5,11 @@ import com.github.fppt.jedismock.RedisServer;
 import java.io.IOException;
 
 /**
- * RedisHelper
+ * A singleton with a RedisHelper for mock redis (JedisMock)
  *
- * @author thinkerou
+ * @author ericdriggs
  */
-public enum MockRedisSingleton  {
+public enum MockRedisHelperSingleton {
 
     INSTANCE;
 
@@ -17,7 +17,7 @@ public enum MockRedisSingleton  {
     private RedisHelper redisHelper;
     private volatile boolean isClosed = false;
 
-    MockRedisSingleton() {
+    MockRedisHelperSingleton() {
         redisServer = JedisMock.getRedisServer();
         redisHelper = new RedisHelper(redisServer.getHost(), redisServer.getBindPort(), 10000, 128);
     }

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/MockRedisHelperSingleton.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/MockRedisHelperSingleton.java
@@ -15,7 +15,7 @@ public enum MockRedisHelperSingleton {
 
     private RedisServer redisServer;
     private RedisHelper redisHelper;
-    private volatile boolean isClosed = false;
+    private volatile boolean isStopped = false;
 
     MockRedisHelperSingleton() {
         redisServer = JedisMock.getRedisServer();
@@ -31,11 +31,11 @@ public enum MockRedisHelperSingleton {
     }
 
     public synchronized void stop() throws IOException {
-        if (isClosed) {
+        if (isStopped) {
             return;
         }
         redisHelper.closeJedisPool();
         redisServer.stop();
-        isClosed = true;
+        isStopped = true;
     }
 }

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/MockRedisSingleton.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/MockRedisSingleton.java
@@ -1,0 +1,41 @@
+package com.github.thinkerou.karate.utils;
+
+import com.github.fppt.jedismock.RedisServer;
+
+import java.io.IOException;
+
+/**
+ * RedisHelper
+ *
+ * @author thinkerou
+ */
+public enum MockRedisSingleton  {
+
+    INSTANCE;
+
+    private RedisServer redisServer;
+    private RedisHelper redisHelper;
+    private volatile boolean isClosed = false;
+
+    MockRedisSingleton() {
+        redisServer = JedisMock.getRedisServer();
+        redisHelper = new RedisHelper(redisServer.getHost(), redisServer.getBindPort(), 10000, 128);
+    }
+
+    public RedisServer getRedisServer() {
+        return redisServer;
+    }
+
+    public RedisHelper getRedisHelper() {
+        return redisHelper;
+    }
+
+    public synchronized void stop() throws IOException {
+        if (isClosed) {
+            return;
+        }
+        redisHelper.closeJedisPool();
+        redisServer.stop();
+        isClosed = true;
+    }
+}

--- a/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/RedisHelper.java
+++ b/karate-grpc-core/src/main/java/com/github/thinkerou/karate/utils/RedisHelper.java
@@ -26,6 +26,12 @@ public final class RedisHelper {
         return jedisPool.getResource();
     }
 
+    public static synchronized void closeJedisPool() {
+        if (jedisPool != null && jedisPool.isClosed()) {
+            jedisPool.close();
+        }
+    }
+
     public Boolean putDescriptorSets(Path descriptorPath) {
         byte[] data;
         try {
@@ -35,7 +41,7 @@ public final class RedisHelper {
             return false;
         }
 
-        try (Jedis jedis = getJedis()){
+        try (Jedis jedis = getJedis()) {
             Long status = jedis.hset(RedisParams.KEY.getText(), RedisParams.FIELD.getText(), data);
             if (status != 1) {
                 return false;
@@ -45,22 +51,17 @@ public final class RedisHelper {
     }
 
     public byte[] getDescriptorSets() {
-        try ( Jedis jedis = getJedis()) {
+        try (Jedis jedis = getJedis()) {
             return jedis.hget(RedisParams.KEY.getText(), RedisParams.FIELD.getText());
         }
     }
 
     public Long deleteDescriptorSets() {
-        try (Jedis jedis = getJedis()){
+        try (Jedis jedis = getJedis()) {
             return jedis.hdel(RedisParams.KEY.getText(), RedisParams.FIELD.getText());
         }
     }
 
-    public static synchronized void closeJedisPool() {
-        if (jedisPool != null && jedisPool.isClosed()) {
-            jedisPool.close();
-        }
-    }
     private static void init() {
         if (jedisPool != null) {
             return;

--- a/karate-grpc-demo/pom.xml
+++ b/karate-grpc-demo/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.github.thinkerou</groupId>
             <artifactId>karate-grpc-proto</artifactId>
-            <version>1.0.6</version>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.thinkerou</groupId>
+            <artifactId>karate-grpc-helper</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.intuit.karate</groupId>

--- a/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/integration/GrpcClientDemo.java
+++ b/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/integration/GrpcClientDemo.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 import com.github.thinkerou.karate.GrpcClient;
+import com.github.thinkerou.karate.RedisGrpcClient;
 import com.github.thinkerou.karate.utils.FileHelper;
+import com.github.thinkerou.karate.utils.MockRedisSingleton;
 
 /**
  * GrpcClientDemo
@@ -16,7 +18,7 @@ public class GrpcClientDemo {
     private static final Logger logger = Logger.getLogger(GrpcClientDemo.class.getName());
 
     public static void main(String[] args) throws IOException {
-        GrpcClient client1 = GrpcClient.create();
+        GrpcClient client1 = new GrpcClient();
         String result1 = client1.list("Greeter", "SayHello", true);
         logger.info(result1);
         result1 = client1.list("helloworld.Greeter/SayHello", true);
@@ -32,7 +34,7 @@ public class GrpcClientDemo {
         // using the following command:
         //   cd karate-demo
         //   mvn exec:java -Dexec.mainClass=com.github.thinkerou.demo.helloworld.HelloWorldServerMain
-        GrpcClient client2 = GrpcClient.create("localhost", 50051);
+        GrpcClient client2 = new RedisGrpcClient("localhost", 50051, MockRedisSingleton.INSTANCE.getRedisHelper());
         String result2 = client2.call("helloworld.Greeter/SayHello", payloads);
         logger.info(result2);
 

--- a/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/integration/GrpcClientDemo.java
+++ b/karate-grpc-demo/src/main/java/com/github/thinkerou/demo/integration/GrpcClientDemo.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 import com.github.thinkerou.karate.GrpcClient;
 import com.github.thinkerou.karate.RedisGrpcClient;
 import com.github.thinkerou.karate.utils.FileHelper;
-import com.github.thinkerou.karate.utils.MockRedisSingleton;
+import com.github.thinkerou.karate.utils.MockRedisHelperSingleton;
 
 /**
  * GrpcClientDemo
@@ -34,7 +34,7 @@ public class GrpcClientDemo {
         // using the following command:
         //   cd karate-demo
         //   mvn exec:java -Dexec.mainClass=com.github.thinkerou.demo.helloworld.HelloWorldServerMain
-        GrpcClient client2 = new RedisGrpcClient("localhost", 50051, MockRedisSingleton.INSTANCE.getRedisHelper());
+        GrpcClient client2 = new RedisGrpcClient("localhost", 50051, MockRedisHelperSingleton.INSTANCE.getRedisHelper());
         String result2 = client2.call("helloworld.Greeter/SayHello", payloads);
         logger.info(result2);
 

--- a/karate-grpc-demo/src/test/java/demo/AbstractTestBase.java
+++ b/karate-grpc-demo/src/test/java/demo/AbstractTestBase.java
@@ -1,7 +1,7 @@
 package demo;
 
 import com.github.thinkerou.karate.helper.Main;
-import com.github.thinkerou.karate.utils.MockRedisSingleton;
+import com.github.thinkerou.karate.utils.MockRedisHelperSingleton;
 import com.intuit.karate.Results;
 import com.intuit.karate.Runner;
 import net.masterthought.cucumber.Configuration;
@@ -62,7 +62,7 @@ public abstract class AbstractTestBase {
 
     @AfterClass
     public static void afterClass() throws IOException {
-        MockRedisSingleton.INSTANCE.stop();
+        MockRedisHelperSingleton.INSTANCE.stop();
     }
 
 }

--- a/karate-grpc-demo/src/test/java/demo/AbstractTestBase.java
+++ b/karate-grpc-demo/src/test/java/demo/AbstractTestBase.java
@@ -1,8 +1,7 @@
 package demo;
 
 import com.github.thinkerou.karate.helper.Main;
-import com.github.thinkerou.karate.utils.JedisMock;
-import com.github.thinkerou.karate.utils.RedisHelper;
+import com.github.thinkerou.karate.utils.MockRedisSingleton;
 import com.intuit.karate.Results;
 import com.intuit.karate.Runner;
 import net.masterthought.cucumber.Configuration;
@@ -63,8 +62,7 @@ public abstract class AbstractTestBase {
 
     @AfterClass
     public static void afterClass() throws IOException {
-        JedisMock.getRedisServer().stop();
-        RedisHelper.closeJedisPool();
+        MockRedisSingleton.INSTANCE.stop();
     }
 
 }

--- a/karate-grpc-demo/src/test/java/demo/AbstractTestBase.java
+++ b/karate-grpc-demo/src/test/java/demo/AbstractTestBase.java
@@ -1,15 +1,20 @@
 package demo;
 
+import com.github.thinkerou.karate.helper.Main;
+import com.github.thinkerou.karate.utils.JedisMock;
+import com.github.thinkerou.karate.utils.RedisHelper;
 import com.intuit.karate.Results;
 import com.intuit.karate.Runner;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
 import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import testing.ServerStart;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -23,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 // important: do not use @RunWith(Karate.class) !
 public abstract class AbstractTestBase {
 
-    protected static final int THREAD_COUNT = 1;
+    protected static final int THREAD_COUNT = 3;
     protected abstract String getFeatures();
     private static ServerStart server;
 
@@ -33,6 +38,7 @@ public abstract class AbstractTestBase {
             server = new ServerStart();
         }
         server.startServer();
+        Main.putTestDescriptorSetsToRedis();
     }
 
     @Test
@@ -53,6 +59,12 @@ public abstract class AbstractTestBase {
         Configuration config = new Configuration(new File("target"), getFeatures());
         ReportBuilder reportBuilder = new ReportBuilder(jsonPaths, config);
         reportBuilder.generateReports();
+    }
+
+    @AfterClass
+    public static void afterClass() throws IOException {
+        JedisMock.getRedisServer().stop();
+        RedisHelper.closeJedisPool();
     }
 
 }

--- a/karate-grpc-demo/src/test/java/demo/DemoGrpcClientSingleton.java
+++ b/karate-grpc-demo/src/test/java/demo/DemoGrpcClientSingleton.java
@@ -2,7 +2,7 @@ package demo;
 
 import com.github.thinkerou.karate.GrpcClient;
 import com.github.thinkerou.karate.RedisGrpcClient;
-import com.github.thinkerou.karate.utils.MockRedisSingleton;
+import com.github.thinkerou.karate.utils.MockRedisHelperSingleton;
 
 public enum DemoGrpcClientSingleton {
     INSTANCE;
@@ -14,6 +14,6 @@ public enum DemoGrpcClientSingleton {
     }
 
     DemoGrpcClientSingleton() {
-        redisGrpcClient = new RedisGrpcClient("localhost", 50051, MockRedisSingleton.INSTANCE.getRedisHelper());
+        redisGrpcClient = new RedisGrpcClient("localhost", 50051, MockRedisHelperSingleton.INSTANCE.getRedisHelper());
     }
 }

--- a/karate-grpc-demo/src/test/java/demo/DemoGrpcClientSingleton.java
+++ b/karate-grpc-demo/src/test/java/demo/DemoGrpcClientSingleton.java
@@ -1,0 +1,19 @@
+package demo;
+
+import com.github.thinkerou.karate.GrpcClient;
+import com.github.thinkerou.karate.RedisGrpcClient;
+import com.github.thinkerou.karate.utils.MockRedisSingleton;
+
+public enum DemoGrpcClientSingleton {
+    INSTANCE;
+
+    RedisGrpcClient redisGrpcClient;
+
+    public GrpcClient getGrpcClient() {
+        return redisGrpcClient;
+    }
+
+    DemoGrpcClientSingleton() {
+        redisGrpcClient = new RedisGrpcClient("localhost", 50051, MockRedisSingleton.INSTANCE.getRedisHelper());
+    }
+}

--- a/karate-grpc-demo/src/test/java/demo/helloworld/bi-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/bi-stream.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('bistream.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/bi-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/bi-stream.feature
@@ -1,9 +1,7 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('bistream.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/client-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/client-stream.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('clientstream.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/client-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/client-stream.feature
@@ -1,9 +1,7 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('clientstream.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/get-feature.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/get-feature.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('get-feature.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/get-feature.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/get-feature.feature
@@ -1,9 +1,7 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('get-feature.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-list.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-list.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create()
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * def response = client.list('Greeter', 'SayHello', true)

--- a/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-list.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-list.feature
@@ -1,9 +1,8 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create()
-    * def client = client.redis()
+    * def GrpcClient = Java.type('com.github.thinkerou.karate.GrpcClient')
+    * def client = new GrpcClient()
 
   Scenario: do it
     * def response = client.list('Greeter', 'SayHello', true)

--- a/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('helloworld.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature
@@ -1,9 +1,7 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('helloworld.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/helloworld-new.feature
@@ -7,6 +7,7 @@ Feature: grpc helloworld example by grpc dynamic client
     * string payload = read('helloworld.json')
     * def response = client.call('helloworld.Greeter/SayHello', payload)
     * def response = JSON.parse(response)
+    * print response
     * match response[0].message == 'Hello thinkerou'
     * def message = response[0].message
 

--- a/karate-grpc-demo/src/test/java/demo/helloworld/list-features.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/list-features.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('list-features.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/list-features.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/list-features.feature
@@ -1,9 +1,7 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('list-features.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/record-route.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/record-route.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('record-route.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/record-route.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/record-route.feature
@@ -1,9 +1,7 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('record-route.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/route-chat-list.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/route-chat-list.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create()
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * def response = client.list('Greeter', 'RouteChat', true)

--- a/karate-grpc-demo/src/test/java/demo/helloworld/route-chat-list.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/route-chat-list.feature
@@ -1,9 +1,8 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create()
-    * def client = client.redis()
+    * def GrpcClient = Java.type('com.github.thinkerou.karate.GrpcClient')
+    * def client = new GrpcClient()
 
   Scenario: do it
     * def response = client.list('Greeter', 'RouteChat', true)

--- a/karate-grpc-demo/src/test/java/demo/helloworld/route-chat.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/route-chat.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('route-chat.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/route-chat.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/route-chat.feature
@@ -1,9 +1,7 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('route-chat.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/server-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/server-stream.feature
@@ -3,7 +3,7 @@ Feature: grpc helloworld example by grpc dynamic client
   Background:
     * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
     * def client = Client.create('localhost', 50051)
-    * def client = client.redis('localhost', 6379)
+    * def client = client.redis()
 
   Scenario: do it
     * string payload = read('serverstream.json')

--- a/karate-grpc-demo/src/test/java/demo/helloworld/server-stream.feature
+++ b/karate-grpc-demo/src/test/java/demo/helloworld/server-stream.feature
@@ -1,9 +1,7 @@
 Feature: grpc helloworld example by grpc dynamic client
 
   Background:
-    * def Client = Java.type('com.github.thinkerou.karate.GrpcClient')
-    * def client = Client.create('localhost', 50051)
-    * def client = client.redis()
+    * def client = Java.type('demo.DemoGrpcClientSingleton').INSTANCE.getGrpcClient();
 
   Scenario: do it
     * string payload = read('serverstream.json')

--- a/karate-grpc-helper/src/main/java/com/github/thinkerou/karate/helper/Main.java
+++ b/karate-grpc-helper/src/main/java/com/github/thinkerou/karate/helper/Main.java
@@ -17,9 +17,18 @@ import com.github.thinkerou.karate.utils.RedisHelper;
 public class Main {
 
     public static void main(String[] args) {
-        String path = System.getProperty("user.home") + DescriptorFile.PROTO_PATH.getText();
+        putTestDescriptorSetsToRedis();
+    }
+
+    public static void putTestDescriptorSetsToRedis() {
+        putDescriptorSetsToRedis(DescriptorFile.PROTO_PATH.getText(), DescriptorFile.PROTO_FILE.getText());
+    }
+
+    public static void putDescriptorSetsToRedis(String protoPath, String protoFile) {
+        String path = System.getProperty("user.home") + protoPath;
         new File(path).mkdirs();
-        Path descriptorPath = Paths.get(path + DescriptorFile.PROTO_FILE.getText());
+        Path descriptorPath = Paths.get(path + protoFile);
+
         if (!Files.exists(descriptorPath)) {
             try {
                 new File(descriptorPath.toString()).createNewFile();
@@ -28,8 +37,7 @@ public class Main {
             }
         }
 
-        String host = "localhost";
-        RedisHelper redisHelper = RedisHelper.create(host, 6379);
+        RedisHelper redisHelper = new RedisHelper();
         if (redisHelper.getDescriptorSets() != null) {
             redisHelper.deleteDescriptorSets();
         }

--- a/karate-grpc-helper/src/main/java/com/github/thinkerou/karate/helper/Main.java
+++ b/karate-grpc-helper/src/main/java/com/github/thinkerou/karate/helper/Main.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import com.github.thinkerou.karate.constants.DescriptorFile;
+import com.github.thinkerou.karate.utils.MockRedisSingleton;
 import com.github.thinkerou.karate.utils.RedisHelper;
 
 /**
@@ -21,10 +22,10 @@ public class Main {
     }
 
     public static void putTestDescriptorSetsToRedis() {
-        putDescriptorSetsToRedis(DescriptorFile.PROTO_PATH.getText(), DescriptorFile.PROTO_FILE.getText());
+        putDescriptorSetsToRedis(MockRedisSingleton.INSTANCE.getRedisHelper(), DescriptorFile.PROTO_PATH.getText(), DescriptorFile.PROTO_FILE.getText());
     }
 
-    public static void putDescriptorSetsToRedis(String protoPath, String protoFile) {
+    public static void putDescriptorSetsToRedis(RedisHelper redisHelper, String protoPath, String protoFile) {
         String path = System.getProperty("user.home") + protoPath;
         new File(path).mkdirs();
         Path descriptorPath = Paths.get(path + protoFile);
@@ -37,7 +38,6 @@ public class Main {
             }
         }
 
-        RedisHelper redisHelper = new RedisHelper();
         if (redisHelper.getDescriptorSets() != null) {
             redisHelper.deleteDescriptorSets();
         }

--- a/karate-grpc-helper/src/main/java/com/github/thinkerou/karate/helper/Main.java
+++ b/karate-grpc-helper/src/main/java/com/github/thinkerou/karate/helper/Main.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import com.github.thinkerou.karate.constants.DescriptorFile;
-import com.github.thinkerou.karate.utils.MockRedisSingleton;
+import com.github.thinkerou.karate.utils.MockRedisHelperSingleton;
 import com.github.thinkerou.karate.utils.RedisHelper;
 
 /**
@@ -22,7 +22,7 @@ public class Main {
     }
 
     public static void putTestDescriptorSetsToRedis() {
-        putDescriptorSetsToRedis(MockRedisSingleton.INSTANCE.getRedisHelper(), DescriptorFile.PROTO_PATH.getText(), DescriptorFile.PROTO_FILE.getText());
+        putDescriptorSetsToRedis(MockRedisHelperSingleton.INSTANCE.getRedisHelper(), DescriptorFile.PROTO_PATH.getText(), DescriptorFile.PROTO_FILE.getText());
     }
 
     public static void putDescriptorSetsToRedis(RedisHelper redisHelper, String protoPath, String protoFile) {


### PR DESCRIPTION
Addresses: https://github.com/pecker-io/karate-grpc/issues/27
as well as thread-safety

**changes:**

* use mock redis
* make thread safe (jedis pooling, synchronization & release resources)
* bump redis client version
* put descriptor sets to mock redis automatically in test module
* update documents and process to follow maven standard practices for unit testing with mvn install and mvn test without pre-requisite steps
* refactor helper Main with method to parameterize descriptor sets
* clarify readme
* use inheritance for clarity on whether client uses Redis
* prefer explicit singletons instead of static members for greater clarity and flexibility